### PR TITLE
Add env example and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment configuration
+GOOGLE_SHEETS_ID=
+GOOGLE_SHEETS_API_KEY=
+LIFF_ID=

--- a/Green-Wxrp-Shop/README.md
+++ b/Green-Wxrp-Shop/README.md
@@ -27,7 +27,14 @@ This project is a mobile-first, multilingual LIFF WebApp for a Thai herbal drink
    ```bash
    npm run dev
    ```
-3. Configure your environment variables for Google Sheets API and LIFF SDK.
+3. Copy `.env.example` to `.env` and fill in the required variables:
+   `GOOGLE_SHEETS_ID`, `GOOGLE_SHEETS_API_KEY`, and `LIFF_ID`.
+
+## Environment Variables
+
+The application uses environment variables for connecting to Google Sheets and
+the LIFF SDK. Create a `.env` file in the project root using the provided
+`.env.example` as a starting point.
 
 ## Folder Structure
 - `src/features/products` - Product list and stock


### PR DESCRIPTION
## Summary
- add `.env.example` with required variables
- document environment setup in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882f8c52db4832baa3411295db97d02