### PR TITLE
Add basic cart functionality

### DIFF
--- a/Green-Wxrp-Shop/green-wxrp-app/src/app/cart/page.tsx
+++ b/Green-Wxrp-Shop/green-wxrp-app/src/app/cart/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { useCart } from "@/features/cart/useCart";
+
+export default function CartPage() {
+  const { items, removeItem, updateItem } = useCart();
+
+  const handleQtyChange = (id: string, qty: number) => {
+    updateItem(id, qty);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Cart</h1>
+      {items.length === 0 && <p>Cart empty</p>}
+      {items.map((item) => (
+        <div key={item.id} className="flex gap-4 items-center">
+          <span className="flex-1">{item.name}</span>
+          <input
+            type="number"
+            value={item.quantity}
+            onChange={(e) => handleQtyChange(item.id, parseInt(e.target.value))}
+            className="border px-2 py-1 w-20"
+            min={1}
+          />
+          <button
+            onClick={() => removeItem(item.id)}
+            className="bg-red-500 text-white px-2 py-1 rounded"
+          >
+            Remove
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/Green-Wxrp-Shop/green-wxrp-app/src/app/layout.tsx
+++ b/Green-Wxrp-Shop/green-wxrp-app/src/app/layout.tsx
@@ -1,6 +1,12 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { CartProvider } from "@/features/cart/CartProvider";
+import dynamic from "next/dynamic";
+
+const CartButton = dynamic(() => import("@/features/cart/CartButton"), {
+  ssr: false,
+});
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +33,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <CartProvider>
+          {children}
+          <CartButton />
+        </CartProvider>
       </body>
     </html>
   );

--- a/Green-Wxrp-Shop/green-wxrp-app/src/app/page.tsx
+++ b/Green-Wxrp-Shop/green-wxrp-app/src/app/page.tsx
@@ -1,103 +1,44 @@
-import Image from "next/image";
+'use client';
+import { useEffect, useState } from 'react';
+import { useCart } from '@/features/cart/useCart';
+
+interface Product {
+  id: string;
+  name: string;
+  price: number;
+  stock: number;
+}
+
+const SAMPLE_PRODUCTS: Product[] = [
+  { id: '1', name: 'Herbal Tea', price: 50, stock: 10 },
+  { id: '2', name: 'Lime Drink', price: 40, stock: 5 },
+  { id: '3', name: 'Ginger Shot', price: 30, stock: 8 },
+];
 
 export default function Home() {
-  return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const [products] = useState<Product[]>(SAMPLE_PRODUCTS);
+  const { addItem } = useCart();
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
+  useEffect(() => {
+    // Here you could fetch products from Google Sheets
+  }, []);
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Products</h1>
+      {products.map((p) => (
+        <div key={p.id} className="flex gap-4 items-center">
+          <span className="flex-1">
+            {p.name} - ฿{p.price}
+          </span>
+          <button
+            onClick={() => addItem({ id: p.id, name: p.name, price: p.price })}
+            className="bg-green-600 text-white px-2 py-1 rounded"
           >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
+            Add to cart
+          </button>
         </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+      ))}
     </div>
   );
 }

--- a/Green-Wxrp-Shop/green-wxrp-app/src/features/cart/CartButton.tsx
+++ b/Green-Wxrp-Shop/green-wxrp-app/src/features/cart/CartButton.tsx
@@ -1,0 +1,16 @@
+'use client';
+import Link from "next/link";
+import { useCart } from "./useCart";
+
+export default function CartButton() {
+  const { items } = useCart();
+  const count = items.reduce((sum, i) => sum + i.quantity, 0);
+  return (
+    <Link
+      href="/cart"
+      className="fixed bottom-4 right-4 bg-blue-600 text-white rounded-full px-4 py-2 shadow-lg"
+    >
+      Cart ({count})
+    </Link>
+  );
+}

--- a/Green-Wxrp-Shop/green-wxrp-app/src/features/cart/CartProvider.tsx
+++ b/Green-Wxrp-Shop/green-wxrp-app/src/features/cart/CartProvider.tsx
@@ -1,0 +1,84 @@
+'use client';
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+export interface CartItem {
+  id: string;
+  name: string;
+  price: number;
+  quantity: number;
+}
+
+interface CartContextProps {
+  items: CartItem[];
+  addItem: (item: Omit<CartItem, "quantity">, qty?: number) => Promise<void>;
+  removeItem: (id: string) => void;
+  updateItem: (id: string, qty: number) => Promise<void>;
+}
+
+const CartContext = createContext<CartContextProps | undefined>(undefined);
+
+const CART_STORAGE_KEY = "cart";
+
+async function validateStock(id: string, qty: number): Promise<boolean> {
+  try {
+    const { google } = await import("googleapis");
+    const sheets = google.sheets({ version: "v4" });
+    const sheetId = process.env.NEXT_PUBLIC_SHEET_ID;
+    if (!sheetId) return true;
+    const range = `Products!A2:E`;
+    const res = await sheets.spreadsheets.values.get({ spreadsheetId: sheetId, range });
+    const rows = res.data.values || [];
+    const row = rows.find((r) => r[0] === id);
+    if (!row) return true;
+    const stock = parseInt(row[4] as string, 10);
+    return qty <= stock;
+  } catch {
+    // fail open
+    return true;
+  }
+}
+
+export function CartProvider({ children }: { children: React.ReactNode }) {
+  const [items, setItems] = useState<CartItem[]>([]);
+
+  useEffect(() => {
+    const raw = localStorage.getItem(CART_STORAGE_KEY);
+    if (raw) setItems(JSON.parse(raw));
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(CART_STORAGE_KEY, JSON.stringify(items));
+  }, [items]);
+
+  const addItem = async (item: Omit<CartItem, "quantity">, qty = 1) => {
+    const existing = items.find((i) => i.id === item.id);
+    const newQty = (existing?.quantity || 0) + qty;
+    if (!(await validateStock(item.id, newQty))) return;
+    if (existing) {
+      setItems((prev) => prev.map((p) => (p.id === item.id ? { ...p, quantity: newQty } : p)));
+    } else {
+      setItems((prev) => [...prev, { ...item, quantity: qty }]);
+    }
+  };
+
+  const removeItem = (id: string) => {
+    setItems((prev) => prev.filter((p) => p.id !== id));
+  };
+
+  const updateItem = async (id: string, qty: number) => {
+    if (!(await validateStock(id, qty))) return;
+    setItems((prev) => prev.map((p) => (p.id === id ? { ...p, quantity: qty } : p)));
+  };
+
+  return (
+    <CartContext.Provider value={{ items, addItem, removeItem, updateItem }}>
+      {children}
+    </CartContext.Provider>
+  );
+}
+
+export function useCartContext() {
+  const ctx = useContext(CartContext);
+  if (!ctx) throw new Error("CartProvider missing");
+  return ctx;
+}

--- a/Green-Wxrp-Shop/green-wxrp-app/src/features/cart/useCart.ts
+++ b/Green-Wxrp-Shop/green-wxrp-app/src/features/cart/useCart.ts
@@ -1,0 +1,4 @@
+'use client';
+import { useCartContext } from "./CartProvider";
+
+export const useCart = useCartContext;


### PR DESCRIPTION
## Summary
- implement cart context with localStorage persistence
- add floating cart button
- display cart page with quantity edits
- show simple product list with add to cart buttons

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6882f8c26ad0832bb6d5e29dec51155e